### PR TITLE
refactor: don't default to central anymore

### DIFF
--- a/src/Finder.scala
+++ b/src/Finder.scala
@@ -56,9 +56,9 @@ object Finder:
 
     def find() = repository.findWith(this)
 
-    /** Update the finder with a new repository give the string name. */
-    def withRepository(name: String) =
-      this.copy(repository = Repository.fromString(name))
+    /** Update the finder with a new repository. */
+    def withRepository(repo: Repository) =
+      this.copy(repository = repo)
 
     /** Update the finder with the desired dependency segments. */
     def withDeps(deps: List[DependencySegment]) =

--- a/src/Main.scala
+++ b/src/Main.scala
@@ -41,9 +41,14 @@ def parseOptions(args: Seq[String]): Finder =
   @tailrec
   def parse(finder: Finder.ActiveFinder, rest: List[String]): Finder =
     rest match
-      case "-r" :: repo :: rest => parse(finder.withRepository(repo), rest)
+      case "-r" :: repo :: rest =>
+        Repository.fromString(repo) match
+          case Left(msg)   => finder.stop(msg)
+          case Right(repo) => parse(finder.withRepository(repo), rest)
       case "--repository" :: repo :: rest =>
-        parse(finder.withRepository(repo), rest)
+        Repository.fromString(repo) match
+          case Left(msg)   => finder.stop(msg)
+          case Right(repo) => parse(finder.withRepository(repo), rest)
       case "-c" :: credentials :: rest =>
         parseCreds(credentials) match
           case Left(msg)    => finder.stop(msg)

--- a/src/tests/Finder.test.scala
+++ b/src/tests/Finder.test.scala
@@ -3,6 +3,7 @@ package io.kipp
 import java.net.URI
 
 import io.kipp.exists.*
+import io.kipp.exists.Repository.SonatypeSnapshots
 
 class FinderTests extends munit.FunSuite:
 
@@ -65,7 +66,7 @@ class FinderTests extends munit.FunSuite:
 
   test("with-repo") {
     assertEquals(
-      baseFinder.withRepository("sonatype:snapshots"),
+      baseFinder.withRepository(SonatypeSnapshots),
       Finder.ActiveFinder(
         found = List.empty,
         toFind = List.empty,

--- a/src/tests/Main.test.scala
+++ b/src/tests/Main.test.scala
@@ -2,8 +2,12 @@
 
 package io.kipp.exists
 
-import io.kipp.exists.Finder.StoppedFinder
+import java.net.URI
+
 import io.kipp.exists.Finder.ActiveFinder
+import io.kipp.exists.Finder.StoppedFinder
+import io.kipp.exists.Repository.SontatypeNexus
+import io.kipp.exists.Repository.SonatypeSnapshots
 
 class MainTests extends munit.FunSuite:
 
@@ -50,7 +54,7 @@ class MainTests extends munit.FunSuite:
       parseOptions(Seq("-r", "sonatype:snapshots") ++ baseArgs)
     assertEquals(
       result,
-      baseFinder.withRepository("sonatype:snapshots")
+      baseFinder.withRepository(SonatypeSnapshots)
     )
   }
 
@@ -66,7 +70,25 @@ class MainTests extends munit.FunSuite:
       )
     assertEquals(
       result,
-      baseFinder.withRepository("sonatype:nexus").withCreds(baseCreds)
+      baseFinder
+        .withRepository(SontatypeNexus(URI("https://mycustomernexusaddres/")))
+        .withCreds(baseCreds)
+    )
+  }
+
+  test("invalid-repo") {
+    val result: Finder =
+      parseOptions(
+        Seq(
+          "-r",
+          "google:myCustomerNexusAddres",
+          "-c",
+          "username:password"
+        ) ++ baseArgs
+      )
+    assertEquals(
+      result,
+      baseFinder.stop("Unrecognized repository.")
     )
   }
 


### PR DESCRIPTION
Instead give the user an invalide repo message. Also do a best
effort at handling hosts that don't have a protocol