### PR TITLE
refactor: change finder to have another state

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    name: Test
+    name: Format check and test
     runs-on: ubuntu-latest
 
     steps:
@@ -18,5 +18,8 @@ jobs:
         with:
           apps: scala-cli
 
+      - name: Format check
+        run: make format-check
+
       - name: Test
-        run: scala-cli test .
+        run: make test

--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,5 +1,6 @@
 version = "3.3.1"
 runner.dialect = scala3
+project.git = true
 
 rewrite.scala3.convertToNewSyntax = yes
 rewrite.scala3.removeOptionalBraces = yes

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,23 @@
+clean:
+	rm exists
+	rm -rf .metals/
+	rm -rf .scala/
+	rm -rf .bsp/
+
+# We can't use scalafmt --check with scala-cli because of:
+# https://github.com/VirtusLab/scala-cli/issues/528
+# So we need to wait for a release with that fix.
+format:
+	cs launch scalafmt -- --check
+
+format-check:
+	cs launch scalafmt -- --check
+
+# For now we don't package with a native image because of:
+# https://github.com/VirtusLab/scala-cli/pull/527
+# So we need to wait for a release with that fix.
+package:
+	scala-cli package . -o exists -f
+
+test:
+	scala-cli test .

--- a/src/Main.scala
+++ b/src/Main.scala
@@ -11,6 +11,7 @@ import scala.annotation.tailrec
     case Seq() | Seq("help") | Seq("--h") | Seq("-h") | Seq("--help") => help()
     case args =>
       parseOptions(args) match
+        case finder: Finder.PreFinder     => finder.activate().find().show()
         case finder: Finder.ActiveFinder  => finder.find().show()
         case finder: Finder.StoppedFinder => finder.show()
 
@@ -39,7 +40,7 @@ end help
   */
 def parseOptions(args: Seq[String]): Finder =
   @tailrec
-  def parse(finder: Finder.ActiveFinder, rest: List[String]): Finder =
+  def parse(finder: Finder.PreFinder, rest: List[String]): Finder =
     rest match
       case "-r" :: repo :: rest =>
         Repository.fromString(repo) match
@@ -63,7 +64,7 @@ def parseOptions(args: Seq[String]): Finder =
           .fold(finder.stop, finder.withDeps)
       case opts => finder.stop("Unrecognized options")
 
-  parse(Finder.ActiveFinder.empty(), args.toList)
+  parse(Finder.PreFinder.empty(), args.toList)
 end parseOptions
 
 def parseCreds(credentials: String): Either[String, Creds] =

--- a/src/tests/Main.test.scala
+++ b/src/tests/Main.test.scala
@@ -4,7 +4,7 @@ package io.kipp.exists
 
 import java.net.URI
 
-import io.kipp.exists.Finder.ActiveFinder
+import io.kipp.exists.Finder.PreFinder
 import io.kipp.exists.Finder.StoppedFinder
 import io.kipp.exists.Repository.SontatypeNexus
 import io.kipp.exists.Repository.SonatypeSnapshots
@@ -13,7 +13,7 @@ class MainTests extends munit.FunSuite:
 
   lazy val baseArgs = Seq("org.scalameta:metals_2.12:")
   lazy val baseFinder =
-    Finder.ActiveFinder
+    PreFinder
       .empty()
       .withDeps(
         List(
@@ -102,7 +102,7 @@ class MainTests extends munit.FunSuite:
       )
     assertEquals(
       result,
-      ActiveFinder.empty().stop("Unrecognized options")
+      PreFinder.empty().stop("Unrecognized options")
     )
   }
 end MainTests


### PR DESCRIPTION
This introduces another state to the finder that makes it start as a
`PreFinder` before it becomes an `ActiveFinder`. This also adds in a
makefile because it will save me maybe seconds of my life. I also added
in a formatting check for now just using cs launch until I can use the
built-in scala-cli check.